### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     include_package_data=False,
     zip_safe=False,
     install_requires=[
-        'xlrd==0.7.1',
+        'xlrd>=0.7.1',
         'openpyxl==1.5.7'
     ],
     tests_require=[],


### PR DESCRIPTION
New xlrd 0.8 supports Office 2007 and I want to use it elsewhere in the CKAN world, but can't because of this tight requirement.
