### PR TITLE
Ignore metadata folders added to zip files by Mac OS X

### DIFF
--- a/messytables/zip.py
+++ b/messytables/zip.py
@@ -16,6 +16,11 @@ class ZIPTableSet(messytables.TableSet):
         try:
             for f in z.infolist():
                 ext = None
+
+                #ignore metadata folders added by Mac OS X
+                if '__MACOSX' in f.filename:
+                    continue
+
                 if "." in f.filename:
                     ext = f.filename[f.filename.rindex(".") + 1:]
 


### PR DESCRIPTION
Ignore metadata folders added to zip files by Mac OS X. 

There's probably similar metadata files on Linux (.trash?) but this is particularly painful because the OSX Finder zip creation silently inserts these folders into the archive even if you are only compressing one file.
