### PR TITLE
html5lib - improved tolerance of malformed HTML tables

### DIFF
--- a/messytables/html.py
+++ b/messytables/html.py
@@ -1,7 +1,13 @@
 from messytables.core import RowSet, TableSet, Cell, CoreProperties
 import lxml.html
 from collections import defaultdict
+import html5lib
+import xml.etree.ElementTree as etree
 
+def fromstring(s):
+    tb = html5lib.getTreeBuilder("lxml", implementation=etree)
+    p = html5lib.HTMLParser(tb, namespaceHTMLElements=False)
+    return p.parse(s)
 
 class HTMLTableSet(TableSet):
     """
@@ -17,7 +23,7 @@ class HTMLTableSet(TableSet):
             raise TypeError('You must provide one of filename or fileobj')
 
         self.htmltables = []
-        root = lxml.html.fromstring(fh.read())
+        root = fromstring(fh.read())
 
         # Grab tables that don't contain tables, remove from root, repeat.
         while True:
@@ -148,7 +154,7 @@ class HTMLCell(Cell):
 
     def __init__(self, value=None, column=None, type=None, source=None):
         assert value is None
-        assert isinstance(source, lxml.html.HtmlElement)
+        assert isinstance(source, lxml.etree._Element)
         self._lxml = source
         if type is None:
             from messytables.types import StringType
@@ -214,7 +220,7 @@ class HTMLProperties(CoreProperties):
     KEYS = ['_lxml', 'html', 'colspan', 'rowspan']
 
     def __init__(self, lxml_element):
-        if not isinstance(lxml_element, lxml.html.HtmlElement):
+        if not isinstance(lxml_element, lxml.etree._Element):
             raise TypeError("%r" % lxml_element)
         super(HTMLProperties, self).__init__()
         self.lxml_element = lxml_element

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'json-table-schema',
         'lxml>=3.2',
         'requests',
+        'html5lib'
     ],
     extras_require={'pdf': ['pdftables>=0.0.4']},
     tests_require=[],

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -69,7 +69,7 @@ class TestHtmlProperties(unittest.TestCase):
 
     def test_real_cells_have_lxml_property(self):
         lxml_element = self.real_cell.properties['_lxml']
-        assert_is_instance(lxml_element, lxml.html.HtmlElement)
+        assert_is_instance(lxml_element, lxml.etree._Element)
         assert_equal('<td colspan="2">06</td>',
                      lxml.html.tostring(lxml_element))
 
@@ -91,6 +91,7 @@ class TestBrokenColspans(unittest.TestCase):
     def setUp(self):
         self.html = any_tableset(horror_fobj("badcolspan.html"),
                                  extension="html")
+
     def test_first_row(self):
         first_row = list(list(self.html.tables)[0])[0]
         self.assertEqual([cell.properties['colspan'] for cell in first_row],


### PR DESCRIPTION
Note, this does raise a few warnings due to the colspan test being malformed. We could change that test to no longer have `""4""` as an attribute.
