### PR TITLE
Fix "tests" to "test"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author_email='info@okfn.org',
     url='http://okfn.org',
     license='MIT',
-    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    packages=find_packages(exclude=['ez_setup', 'examples', 'test']),
     namespace_packages=[],
     include_package_data=False,
     zip_safe=False,


### PR DESCRIPTION
Before this change, we accidentally install a "test" package
when using pip install. This avoids that.