### PR TITLE
commas.UTF8Recoder doesn't remove BOM from UTF-8 files

### DIFF
--- a/messytables/commas.py
+++ b/messytables/commas.py
@@ -11,6 +11,16 @@ class UTF8Recoder:
     """
     Iterator that reads an encoded stream and re-encodes the input to UTF-8
     """
+
+    # maps between chardet encoding and codecs bom keys
+    BOM_MAPPING = {
+        'utf-16le': 'BOM_UTF16_LE',
+        'utf-16be': 'BOM_UTF16_BE',
+        'utf-32le': 'BOM_UTF32_LE',
+        'utf-32be': 'BOM_UTF32_BE',
+        'utf-8': 'BOM_UTF8'
+    }
+
     def __init__(self, f, encoding):
         sample = f.read(2000)
         if not encoding:
@@ -30,9 +40,8 @@ class UTF8Recoder:
         # endianness explicit, which results in the codecs stream leaving the
         # BOM in the stream. This is ridiculously dumb. For UTF-{16,32}{LE,BE}
         # encodings, check for a BOM and remove it if it's there.
-        if encoding in ("UTF-16LE", "UTF-16BE", "UTF-32LE", "UTF-32BE"):
-            bom = getattr(codecs, "BOM_UTF" + encoding[4:6] +
-                          "_" + encoding[-2:], None)
+        if encoding.lower() in self.BOM_MAPPING:
+            bom = getattr(codecs, self.BOM_MAPPING[encoding.lower()], None)
             if bom:
                 # Try to read the BOM, which is a byte sequence, from
                 # the underlying stream. If all characters match, then


### PR DESCRIPTION
If a BOM is present in a UTF-16LE, UTF-16BE, UTF-32LE or UTF-32BE file, the class will skip it during line iteration [1]. However, UTF-8 files that contain a BOM will retain it.

[1] https://github.com/okfn/messytables/blob/1bd2da6257348442421ea13e9312a363fb408b4e/messytables/commas.py#L33-L45