### PR TITLE
0.2 of json-table-schema fails to install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'python-magic==0.4.6',  # used for type guessing
         'chardet==2.1.1',
         'python-dateutil>=1.5.0,<2.0.0',
-        'json-table-schema',
+        'json-table-schema<0.2',
         'lxml>=3.2',
         'requests',
         'html5lib'


### PR DESCRIPTION
i was having trouble installing messytables and finally saw that the latest release (1 day ago) of json-table-schema was the problem.

i kept getting 

```
Searching for json-table-schema
Reading http://pypi.python.org/simple/json-table-schema/
Best match: json-table-schema 0.2.linux-i686
Downloading https://pypi.python.org/packages/any/j/json-table-schema/json-table-schema-0.2.linux-i686.tar.gz#md5=38d15bf52820adb92b8da3db51ec0c84
Processing json-table-schema-0.2.linux-i686.tar.gz
error: Couldn't find a setup script in /tmp/easy_install-mAhBRX/json-table-schema-0.2.linux-i686.tar.gz

```

