### PR TITLE
Pass any_tableset arguments through to specific parsers.

### DIFF
--- a/messytables/any.py
+++ b/messytables/any.py
@@ -110,7 +110,7 @@ def guess_ext(ext):
         return lookup.get(ext, None)
 
 
-def any_tableset(fileobj, mimetype=None, extension='', auto_detect=True):
+def any_tableset(fileobj, mimetype=None, extension='', auto_detect=True, **kw):
     """Reads any supported table type according to a specified
     MIME type or file extension or automatically detecting the
     type.
@@ -133,7 +133,7 @@ def any_tableset(fileobj, mimetype=None, extension='', auto_detect=True):
     if mimetype is not None:
         attempt = guess_mime(mimetype)
         if attempt:
-            return parsers[attempt](fileobj)
+            return parsers[attempt](fileobj, **kw)
         else:
             error.append(
                 'Did not recognise MIME type given: "{mimetype}".'.format(
@@ -142,7 +142,7 @@ def any_tableset(fileobj, mimetype=None, extension='', auto_detect=True):
     if short_ext is not '':
         attempt = guess_ext(short_ext)
         if attempt:
-            return parsers[attempt](fileobj)
+            return parsers[attempt](fileobj, **kw)
         else:
             error.append(
                 'Did not recognise extension "{ext}" (given "{full})".'.format(
@@ -152,7 +152,7 @@ def any_tableset(fileobj, mimetype=None, extension='', auto_detect=True):
         magic_mime = get_mime(fileobj)
         attempt = guess_mime(magic_mime)
         if attempt:
-            return parsers[attempt](fileobj)
+            return parsers[attempt](fileobj, **kw)
         else:
             error.append(
                 'Did not recognise detected MIME type: "{mimetype}".'.format(

--- a/messytables/commas.py
+++ b/messytables/commas.py
@@ -66,6 +66,7 @@ class UTF8Recoder:
 
     next = __next__
 
+
 def to_unicode_or_bust(obj, encoding='utf-8'):
     if isinstance(obj, byte_string):
         obj = unicode_string(obj, encoding)
@@ -78,7 +79,7 @@ class CSVTableSet(TableSet):
 
     def __init__(self, fileobj, delimiter=None, quotechar=None, name=None,
                  encoding=None, window=None, doublequote=None,
-                 lineterminator=None, skipinitialspace=None):
+                 lineterminator=None, skipinitialspace=None, **kw):
         self.fileobj = messytables.seekable_stream(fileobj)
         self.name = name or 'table'
         self.delimiter = delimiter
@@ -113,6 +114,7 @@ class CSVRowSet(RowSet):
         self.name = name
         seekable_fileobj = messytables.seekable_stream(fileobj)
         self.fileobj = UTF8Recoder(seekable_fileobj, encoding)
+
         def fake_ilines(fobj):
             for row in fobj:
                     yield row.decode('utf-8')
@@ -181,7 +183,7 @@ class CSVRowSet(RowSet):
 
         try:
             for row in csv.reader(rows(),
-                    dialect=self._dialect, **self._overrides):
+                                  dialect=self._dialect, **self._overrides):
                 yield [Cell(to_unicode_or_bust(c)) for c in row]
         except csv.Error as err:
             if u'newline inside string' in unicode_string(err) and sample:

--- a/messytables/excel.py
+++ b/messytables/excel.py
@@ -25,12 +25,13 @@ XLS_TYPES = {
     4: IntegerType()
 }
 
+
 class XLSTableSet(TableSet):
     """An excel workbook wrapper object.
     """
 
-    def __init__(self, fileobj=None, filename=None,
-                 window=None, encoding=None, with_formatting_info=True):
+    def __init__(self, fileobj=None, filename=None, window=None,
+                 encoding=None, with_formatting_info=True, **kw):
         '''Initialize the tableset.
 
         :param encoding: passed on to xlrd.open_workbook function

--- a/messytables/html.py
+++ b/messytables/html.py
@@ -4,16 +4,18 @@ from collections import defaultdict
 import html5lib
 import xml.etree.ElementTree as etree
 
+
 def fromstring(s):
     tb = html5lib.getTreeBuilder("lxml", implementation=etree)
     p = html5lib.HTMLParser(tb, namespaceHTMLElements=False)
     return p.parse(s)
 
+
 class HTMLTableSet(TableSet):
     """
     A TableSet from a HTML document.
     """
-    def __init__(self, fileobj=None, filename=None, window=None):
+    def __init__(self, fileobj=None, filename=None, window=None, **kw):
 
         if filename is not None:
             fh = open(filename, 'r')

--- a/messytables/ods.py
+++ b/messytables/ods.py
@@ -19,6 +19,7 @@ ODS_TYPES = {
     'date': DateType(None),
 }
 
+
 class ODSTableSet(TableSet):
     """
     A wrapper around ODS files. Because they are zipped and the info we want
@@ -27,7 +28,7 @@ class ODSTableSet(TableSet):
     the remote URL.
     """
 
-    def __init__(self, fileobj, window=None):
+    def __init__(self, fileobj, window=None, **kw):
         '''Initialize the object.
 
         :param fileobj: may be a file path or a file-like object. Note the

--- a/messytables/pdf.py
+++ b/messytables/pdf.py
@@ -45,7 +45,7 @@ class PDFTableSet(TableSet):
     """
     A TableSet from a PDF document.
     """
-    def __init__(self, fileobj=None, filename=None):
+    def __init__(self, fileobj=None, filename=None, **kw):
         if get_tables is None:
             raise ImportError("pdftables is not installed")
         if filename is not None:

--- a/messytables/types.py
+++ b/messytables/types.py
@@ -83,7 +83,7 @@ class IntegerType(CellType):
         if value.is_integer():
             return int(value)
         else:
-            raise ValueError()
+            raise ValueError('Invalid integer: %s' % value)
 
 
 class DecimalType(CellType):

--- a/messytables/zip.py
+++ b/messytables/zip.py
@@ -6,7 +6,7 @@ import messytables
 class ZIPTableSet(messytables.TableSet):
     """ Reads TableSets from inside a ZIP file """
 
-    def __init__(self, fileobj):
+    def __init__(self, fileobj, **kw):
         """
         On error it will raise messytables.ReadError.
         """
@@ -17,7 +17,7 @@ class ZIPTableSet(messytables.TableSet):
             for f in z.infolist():
                 ext = None
 
-                #ignore metadata folders added by Mac OS X
+                # ignore metadata folders added by Mac OS X
                 if '__MACOSX' in f.filename:
                     continue
 
@@ -26,7 +26,7 @@ class ZIPTableSet(messytables.TableSet):
 
                 try:
                     filetables = messytables.any.any_tableset(
-                        z.open(f), extension=ext)
+                        z.open(f), extension=ext, **kw)
                 except ValueError as e:
                     found.append(f.filename + ": " + e.message)
                     continue
@@ -38,5 +38,5 @@ class ZIPTableSet(messytables.TableSet):
                     tables (%s).''' % ', '.join(found))
         finally:
             z.close()
-        
+
         self._tables = tables


### PR DESCRIPTION
I have a lot of detection errors right now which would be fixed by a larger window size. Rather than doing that in messytables, I'd like to be able to pass ``window=10000`` to the ``any_tableset`` method and override the window size that way.

Should be fully backward compatible. 