### PR TITLE
Updated requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'lxml>=3.2',
         'requests',
         'html5lib',
-        'json-table-schema>=0.2'
+        'jsontableschema>=0.5.1'
     ],
     extras_require={'pdf': ['pdftables>=0.0.4']},
     tests_require=[],


### PR DESCRIPTION
 Fixed obsolete json-table-schema package.

```
  Downloading json-table-schema-0.5.0.tar.gz
    Complete output from command python setup.py egg_info:
    json-table-schema has been replaced by jsontableschema. See https://github.com/okfn/json-table-schema-py-old for details.
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-dxZFzP/json-table-schema/setup.py", line 16, in <module>
        with io.open(README_PATH, mode='r+t', encoding='utf-8') as stream:
    IOError: [Errno 2] No such file or directory: '/tmp/pip-build-dxZFzP/json-table-schema/README.md'
```