### PR TITLE
Fix upper limit for json-table-schema version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'lxml>=3.2',
         'requests',
         'html5lib',
-        'json-table-schema>=0.2'
+        'json-table-schema>=0.2, <=0.2.1'
     ],
     extras_require={'pdf': ['pdftables>=0.0.4']},
     tests_require=[],


### PR DESCRIPTION
Because the next version of json-table-schema is going to be "completely different": https://github.com/okfn/messytables/issues/135#issuecomment-153724795

This doesn't mean we can't start using the new one, as suggested in #135, but that's a bigger job.