### PR TITLE
Min python-dateutil version changed back to 1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'lxml>=3.2',
         'requests',
         'html5lib',
-        'json-table-schema>=0.2'
+        'json-table-schema>=0.2, <=0.2.1'
     ],
     extras_require={'pdf': ['pdftables>=0.0.4']},
     tests_require=[],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'xlrd>=0.8.0',
         'python-magic>=0.4.6',  # used for type guessing
         'chardet>=2.3.0',
-        'python-dateutil>=2.4.2',
+        'python-dateutil>=1.5.0',
         'lxml>=3.2',
         'requests',
         'html5lib',


### PR DESCRIPTION
The min version was changed from 1.5 to 2.4.2 (released March 2015) in this commit:
https://github.com/karol-szuster/messytables/commit/3e5ce38c76e5ad9578b62d6246a1a6f92e574ce4
but I'm not clear that any new features have been used. Tests pass with dateutil 1.5, which would suit CKAN, amongst others.