### PR TITLE
Properly convert messytables types to strings

### DIFF
--- a/messytables/__init__.py
+++ b/messytables/__init__.py
@@ -22,4 +22,4 @@ from messytables.html import HTMLTableSet, HTMLRowSet
 from messytables.pdf import PDFTableSet, PDFRowSet
 from messytables.any import any_tableset, AnyTableSet
 
-from messytables.jts import rowset_as_jts, headers_and_typed_as_jts
+from messytables.jts import rowset_as_jts, headers_and_types_as_jts

--- a/messytables/jts.py
+++ b/messytables/jts.py
@@ -30,7 +30,7 @@ def rowset_as_jts(rowset, headers=None, types=None):
     return headers_and_typed_as_jts(headers, types)
 
 
-def headers_and_typed_as_jts(headers, types):
+def headers_and_types_as_jts(headers, types):
     ''' Create a json table schema from headers and types as
     returned from :meth:`~messytables.headers.headers_guess`
     and :meth:`~messytables.types.type_guess`.
@@ -40,6 +40,6 @@ def headers_and_typed_as_jts(headers, types):
     for field_id, field_type in zip(headers, types):
         j.add_field(field_id=field_id,
                     label=field_id,
-                    field_type=field_type)
+                    field_type=celltype_as_string(field_type))
 
     return j

--- a/messytables/jts.py
+++ b/messytables/jts.py
@@ -27,7 +27,7 @@ def rowset_as_jts(rowset, headers=None, types=None):
     _, headers = messytables.headers_guess(rowset.sample)
     types = list(map(celltype_as_string, messytables.type_guess(rowset.sample)))
 
-    return headers_and_typed_as_jts(headers, types)
+    return headers_and_types_as_jts(headers, types)
 
 
 def headers_and_types_as_jts(headers, types):


### PR DESCRIPTION
JSONTableSchema.add_field expects a string type name, but was getting an instance of CellType - this patch properly converts the types to strings using the existing mapping. 

Also, fix assumed typo in function name - headers_and_typed -> headers_and_types.