### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 A library for dealing with messy tabular data in several formats, guessing types and detecting headers.
 
-See the documentation at: https://messytables.readthedocs.org
+See the documentation at: https://messytables.readthedocs.io
 
 Find the package at: https://pypi.python.org/pypi/messytables
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -148,7 +148,7 @@ PDF file support
 ----------------
 
 The library supports PDF documents, using
-`pdftables <https://pdftables.readthedocs.org>`_ to extract tables.
+`pdftables <https://pdftables.readthedocs.io>`_ to extract tables.
 
 Works only for PDFs which contain text information: somewhat erratic in quality.
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ This library provides data structures and some heuristics to
 fix these problems and read a wide number of different tabular
 abominations.
 
-See the full documentation at: http://messytables.readthedocs.org
+See the full documentation at: https://messytables.readthedocs.io
 """
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.