### PR TITLE
HTTPSify URLs in layout.html

### DIFF
--- a/doc/_themes/flask_small/layout.html
+++ b/doc/_themes/flask_small/layout.html
@@ -14,8 +14,8 @@
 {% block relbar1 %}{% endblock %}
 {% block relbar2 %}
   {% if theme_github_fork %}
-    <a href="http://github.com/{{ theme_github_fork }}"><img style="position: fixed; top: 0; right: 0; border: 0;"
-    src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+    <a href="https://github.com/{{ theme_github_fork }}"><img style="position: fixed; top: 0; right: 0; border: 0;"
+    src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
   {% endif %}
 {% endblock %}
 {% block sidebar1 %}{% endblock %}


### PR DESCRIPTION
Making the S3 URL HTTPS allows readers to view the documentation on
readthedocs as HTTPS without mixed content warnings.