### PR TITLE
Fix for Python Magic API change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - "2.7"
   - "3.4"
 install:
+  # Fix for html5lib, probably can be removed after the version after
+  # 0.999999999/1.0b10 is released.
+  - pip install --upgrade setuptools
   - pip install -e .
   - pip install -r requirements-test.txt
   - pip install coveralls

--- a/messytables/any.py
+++ b/messytables/any.py
@@ -63,7 +63,7 @@ def get_mime(fileobj):
     # seek back later. If not, slurp in the contents into a StringIO.
     fileobj = messytables.seekable_stream(fileobj)
     header = fileobj.read(4096)
-    mimetype = magic.from_buffer(header, mime=True).decode('utf-8')
+    mimetype = magic.from_buffer(header, mime=True)
     fileobj.seek(0)
     if MIMELOOKUP.get(mimetype) == 'ZIP':
         # consider whether it's an Microsoft Office document

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,7 +3,7 @@ nose==1.3.6
 requests==2.2.1
 # pdftables==0.0.4
 xlrd==0.9.3
-python-magic==0.4.6
+python-magic==0.4.12
 chardet==2.3.0
 python-dateutil==2.4.2
 lxml==3.3.3

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'xlrd>=0.8.0',
-        'python-magic>=0.4.6',  # used for type guessing
+        'python-magic>=0.4.12',  # used for type guessing
         'chardet>=2.3.0',
         'python-dateutil>=1.5.0',
         'lxml>=3.2',


### PR DESCRIPTION
[Here](https://github.com/ahupp/python-magic/commit/b1666986236eab820e9155a5943d6b94938b4c40), python-magic changed the behaviour of `from_buffer()`.

This breaks a new install of messytables on Python 3.4, shown by tests failing:

```
  File ".../messytables/messytables/any.py", line 66, in get_mime
    mimetype = magic.from_buffer(header, mime=True).decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
```

The alternative fix would be to pin python-magic at some version <0.4.12.
