### PR TITLE
Add CDFV2-unknown to MIMELOOKUP

### DIFF
--- a/messytables/any.py
+++ b/messytables/any.py
@@ -24,6 +24,7 @@ MIMELOOKUP = {'application/x-zip-compressed': 'ZIP',
               'application/pdf': 'PDF',
               'text/plain': 'CSV',  # could be TAB.
               'application/CDFV2-corrupt': 'XLS',
+              'application/CDFV2-unknown': 'XLS',
               'application/vnd.oasis.opendocument.spreadsheet': 'ODS',
               'application/x-vnd.oasis.opendocument.spreadsheet': 'ODS',
               }


### PR DESCRIPTION
For wpp.xls in xypath's test fixtures
(https://github.com/sensiblecodeio/xypath), the result of detecting MIME
type with file is "application/CDFV2-unknown" when using recent versions
of file (tested on file 5.25), and only looking at the first 4K of the
xls as messytables does. This isn't currently recognised and causes
messytables to fail when autodetecting file type in get_mime().

messytables.error.ReadError: Did not recognise detected MIME type:
"application/CDFV2-unknown".

(NB: if the whole file is used for detection, the MIME type with file
5.25 is "application/vnd.ms-excel" which would be allowed by
messytables.)

Think the change in file is here:
https://github.com/file/file/commit/4c195c2c22236b8cd169b80ef1809ab753d36b25#diff-164f7aa10d841313928ec217ed258cbfL519