### PR TITLE
Release as 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+0.15.1 (29 September 2016)
+* #158: Add CDFV2-unknown to MIMELOOKUP
+* #157: Fix for Python Magic API change
+* #156: HTTPSify URLs in layout.html
+* #153: Convert readthedocs links for their .org -> .io migration for
+  hosted projects
+* #147: Min python-dateutil version changed back to 1.5
+* #145: Fix upper limit for json-table-schema version
+* #143: Updated requirements.
+* #141: Don't parse inputs with length 1 as dates #140
+* #136: Pass any\_tableset arguments through to specific parsers.
+
 0.15 (19 June 2015)
 * #124 Python 2/3 multilingual.
 * #125 Fix ODS stopping at blank lines

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     keywords='',
     author='Open Knowledge Foundation',
     author_email='info@okfn.org',
-    url='http://okfn.org',
+    url='https://okfn.org',
     license='MIT',
     packages=find_packages(exclude=['ez_setup', 'examples', 'test']),
     namespace_packages=[],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ See the full documentation at: https://messytables.readthedocs.io
 
 setup(
     name='messytables',
-    version='0.15.0',
+    version='0.15.1',
     description="Parse messy tabular data in various formats",
     long_description=long_desc,
     classifiers=[


### PR DESCRIPTION
Update from previous version.

I don't think any of the recent PRs break backwards compatibility, so increased
patch version of 0.15 to .1 for new release.

(See CHANGELOG.md for details.)