### PR TITLE
catch TypeError if value has no len

### DIFF
--- a/messytables/types.py
+++ b/messytables/types.py
@@ -185,9 +185,12 @@ class DateUtilType(CellType):
     result_type = datetime.datetime
 
     def test(self, value):
-        if len(value) == 1:
-             return False
-        return CellType.test(self, value)
+        try:
+            if len(value) == 1:
+                return False
+            return CellType.test(self, value)
+        except TypeError:
+            return False
 
     def cast(self, value):
         if value in ('', None):

--- a/messytables/types.py
+++ b/messytables/types.py
@@ -188,9 +188,9 @@ class DateUtilType(CellType):
         try:
             if len(value) == 1:
                 return False
-            return CellType.test(self, value)
         except TypeError:
-            return False
+            pass
+        return CellType.test(self, value)
 
     def cast(self, value):
         if value in ('', None):


### PR DESCRIPTION
If the value we are dealing with has no len, e.g. float, a TypeError is thrown and the guess fails.

This PR is based on the suggestion made in #163 but I am happy to discuss this approach!

FYI: I ran the tests with my changes and without my changes and both resulted as follows:
FAILED (SKIP=4, errors=9)